### PR TITLE
Use JWT auth for cloudflare API

### DIFF
--- a/hook.py
+++ b/hook.py
@@ -31,8 +31,7 @@ logger.setLevel(logging.INFO)
 
 try:
     CF_HEADERS = {
-        'X-Auth-Email': os.environ['CF_EMAIL'],
-        'X-Auth-Key'  : os.environ['CF_KEY'],
+        'Authorization': 'Bearer ' + os.environ['CF_TOKEN'],
         'Content-Type': 'application/json',
     }
 except KeyError:


### PR DESCRIPTION
# Summary

This uses a JWT to authenticate with Cloudflare instead of the old X-Auth.

I have manually tested this by updating the metabase certificate with the new script.

Please see:
https://api.cloudflare.com/#getting-started-requests